### PR TITLE
Replace IIS and Kestrel to wrap Web API with provider classes for Lambda runtime support

### DIFF
--- a/MasadaSecurity/LambdaEntryPoint.cs
+++ b/MasadaSecurity/LambdaEntryPoint.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using Microsoft.AspNetCore.Hosting;
+
+namespace MasadaSecurity
+{
+    public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+    {
+        /// <summary>
+        ///     The builder has configuration, logging and Amazon API Gateway already configured. The startup class
+        ///     needs to be configured in this method using the UseStartup<>() method.
+        /// </summary>
+        /// <param name="builder"></param>
+        protected override void Init(IWebHostBuilder builder)
+        {
+            builder
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseStartup<Startup>()
+                .UseApiGateway();
+        }
+    }
+}

--- a/MasadaSecurity/LocalEntryPoint.cs
+++ b/MasadaSecurity/LocalEntryPoint.cs
@@ -9,7 +9,10 @@ using System.Threading.Tasks;
 
 namespace MasadaSecurity
 {
-    public class Program
+    /// <summary>
+    ///  The Main function can be used to run the ASP.NET Core application locally using the Kestrel webserver.
+    /// </summary>
+    public class LocalEntryPoint
     {
         public static void Main(string[] args)
         {

--- a/MasadaSecurity/MasadaSecurity.csproj
+++ b/MasadaSecurity/MasadaSecurity.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.0.1" />
     <PackageReference Include="MailKit" Version="2.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.4" />
   </ItemGroup>

--- a/MasadaSecurity/Startup.cs
+++ b/MasadaSecurity/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace MasadaSecurity
 {
@@ -37,7 +38,7 @@ namespace MasadaSecurity
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             if (env.IsDevelopment())
             {
@@ -53,6 +54,8 @@ namespace MasadaSecurity
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
+
+            loggerFactory.AddLambdaLogger(Configuration.GetLambdaLoggerOptions());
 
             app.UseRouting();
 

--- a/MasadaSecurity/appsettings.Development.json
+++ b/MasadaSecurity/appsettings.Development.json
@@ -1,9 +1,8 @@
 {
-  "Logging": {
+  "Lambda.Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "Microsoft": "Information"
     }
   }
 }


### PR DESCRIPTION
Hi @MarkellRichards this pull request aims to shed light on how you can run your  ASP.NET Core Web API with Lambda.

The core logic for this is abstracted away in: https://www.nuget.org/packages/Amazon.Lambda.AspNetCoreServer/

The 'LambdaEntryPoint' is used for the Lambda to point to, and for local debugging you can just make use of IIS Express, it will actually make use of the 'LocalEntryPoint'.

When running an ASP.NET Core application as an AWS Serverless application, IIS is replaced with API Gateway and Kestrel is replaced with a Lambda function contained in the Amazon.Lambda.AspNetCoreServer package which marshals the request into the ASP.NET Core hosting framework.

The actual Lambda function comes from the base class. The function handler for the Lambda function is set in the AWS which will be in the format: MasadaSecurity::MasadaSecurity.LambdaEntryPoint::FunctionHandlerAsync

The remainder of the project’s files are the usual ones you would find in an ASP.NET Core application.

 This logging provider allows any code that uses the ILogger interface to record log messages to the associated Amazon CloudWatch log group for the Lambda function. When used outside of a Lambda function, the log messages are written to the console.

I highly recommend you to open the console and go to AWS Lambda and click 'create a function' read about how it's done and upload the zip code manually or via S3, you can read about this if you feel like.

When creating  the API Gateway you should use 'proxy' integration, please read here: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html

Feel free to bother me if you're stuck with setting up the API Gateway or Lambda, I might respond slow (see this is a proof-of-concept) and play with it, open the solution and just hit F5. 